### PR TITLE
Replace Swift 4.2 types in WhatsNewViewController+HapticFeedback.swift

### DIFF
--- a/Sources/Configuration/WhatsNewViewController+HapticFeedback.swift
+++ b/Sources/Configuration/WhatsNewViewController+HapticFeedback.swift
@@ -13,11 +13,11 @@ public extension WhatsNewViewController {
     /// The HapticFeedback Enumeration
     enum HapticFeedback: Equatable {
         /// ImpactFeedback with FeedbackStyle
-        case impact(UIImpactFeedbackGenerator.FeedbackStyle)
+        case impact(UIImpactFeedbackStyle)
         /// SelectionFeedback
         case selection
         /// NotificationFeedback with FeedbackType
-        case notification(UINotificationFeedbackGenerator.FeedbackType)
+        case notification(UINotificationFeedbackType)
         
         /// Execute HapticFeedback
         func execute() {


### PR DESCRIPTION
This is necessary for WhatsNewKit to compile in Swift 4.1 mode.