### PR TITLE
Added the option to show the title view in the items controller

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -4,7 +4,7 @@
 - Xcode version:
 - Swift version:
 - macOS version running Xcode:
-- Dependency manager (Carthage, CocoaPods, Manually):
+- Dependency manager (SPM, Carthage, CocoaPods, Manually):
 
 ## What did you do?
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,9 +3,17 @@ name: CI
 on: [push]
 
 jobs:
-  test:
+  tests:
+    name: Unit-Tests
     runs-on: macOS-latest
     steps:
     - uses: actions/checkout@v1
-    - name: Perform Test
-      run: fastlane test
+    - name: fastlane ios tests
+      run: fastlane ios tests
+  compatibility:
+    name: Compatibility-Tests
+    runs-on: macOS-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: fastlane ios compatibilityTests
+      run: fastlane ios compatibilityTests

--- a/.jazzy.yaml
+++ b/.jazzy.yaml
@@ -1,6 +1,6 @@
 # WhatsNewKit document generator jazzy settings
 
-copyright: Copyright 2018 Sven Tiigi
+copyright: Copyright 2020 Sven Tiigi
 author: Sven Tiigi
 github_url: https://github.com/SvenTiigi/WhatsNewKit
 xcodebuild_arguments: [-target, WhatsNewKit-iOS]

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -21,5 +21,5 @@ disabled_rules: # rule identifiers to exclude from running
   - identifier_name
 
 line_length: 130
-file_length: 410
+file_length: 420
 cyclomatic_complexity: 13

--- a/Example/Configurations/TitleModeConfiguration.swift
+++ b/Example/Configurations/TitleModeConfiguration.swift
@@ -1,0 +1,41 @@
+//
+//  TitleModeConfiguration.swift
+//  WhatsNewKit-Example
+//
+//  Created by Timothy Ellis on 11/4/20.
+//  Copyright © 2020 WhatsNewKit. All rights reserved.
+//
+
+import Foundation
+import WhatsNewKit
+
+/// The TitleModeConfiguration
+class TitleModeConfiguration: Configuration {
+    
+    /// The Title
+    let title: String = "Title Mode 🔧"
+    
+    /// The Subtitle
+    let subtitle: String = "Define how the title will be shown"
+    
+    /// The Options
+    let options = [
+        "Fixed",
+        "Scrolls"
+    ]
+    
+    /// The selected Index
+    var selectedIndex: Int = 0
+    
+    /// Configure WhatsNewViewController.Configuration
+    ///
+    /// - Parameter configuration: The WhatsNewViewController.Configuration
+    func configure(configuration: inout WhatsNewViewController.Configuration) {
+        if self.selectedIndex == 0 {
+            configuration.titleMode = .fixed
+        } else if self.selectedIndex == 1 {
+            configuration.titleMode = .scrolls
+        }
+    }
+    
+}

--- a/Example/ExampleViewController/ExampleViewController.swift
+++ b/Example/ExampleViewController/ExampleViewController.swift
@@ -90,6 +90,7 @@ class ExampleViewController: UIViewController {
         ContentModeConfiguration(),
         HapticFeedbackConfiguration(),
         SecondaryTitleColorConfiguration(),
+        TitleModeConfiguration(),
         ItemsCountConfiguration()
     ]
     

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2019 Sven Tiigi
+Copyright (c) 2020 Sven Tiigi
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -620,7 +620,7 @@ The `WhatsNew.Item` images ([icons8-github](https://icons8.com/icon/62856/github
 
 ```
 WhatsNewKit
-Copyright (c) 2019 Sven Tiigi <sven.tiigi@gmail.com>
+Copyright (c) 2020 Sven Tiigi <sven.tiigi@gmail.com>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Sources/Configuration/WhatsNewViewController+Configuration.swift
+++ b/Sources/Configuration/WhatsNewViewController+Configuration.swift
@@ -17,6 +17,9 @@ public extension WhatsNewViewController {
         
         // MARK: Properties
         
+        /// The title view display mode
+        public var titleMode: TitleMode
+        
         /// The background color
         public var backgroundColor: UIColor
 
@@ -61,12 +64,14 @@ public extension WhatsNewViewController {
         ///   - padAdjustment: The The iPad Adjustment Closure. Default value `defaultPadAdjustment`
         public init(theme: Theme = .default,
                     backgroundColor: UIColor = .whatsNewKitBackground,
+                    titleMode: TitleMode = .fixed,
                     titleView: TitleView = .init(),
                     itemsView: ItemsView = .init(),
                     detailButton: DetailButton? = nil,
                     completionButton: CompletionButton = .init(),
                     padAdjustment: @escaping PadAdjustment = Configuration.defaultPadAdjustment) {
             self.backgroundColor = backgroundColor
+			self.titleMode = titleMode
             self.titleView = titleView
             self.itemsView = itemsView
             self.detailButton = detailButton
@@ -84,6 +89,21 @@ public extension WhatsNewViewController {
         
     }
     
+}
+
+// MARK: - TitleMode
+
+public extension WhatsNewViewController.Configuration {
+    
+    /// Used to describe how the title view should be styled.
+    enum TitleMode {
+        
+        /// The title view should remain fixed at the top, regardless of scrolling
+        case fixed
+        
+        /// The title view should scroll with the rest of the items (out of view)
+        case scrolls
+    }
 }
 
 // MARK: - PadAdjustment

--- a/Sources/WhatsNewViewController.swift
+++ b/Sources/WhatsNewViewController.swift
@@ -237,23 +237,42 @@ public final class WhatsNewViewController: UIViewController {
 
 extension WhatsNewViewController {
     
+    private func getHeaderView() -> UIView {
+        let headerView = self.titleViewController.view as UIView
+        let height = headerView.intrinsicContentSize.height +
+            self.configuration.titleView.insets.top +
+            self.configuration.titleView.insets.bottom
+        var bounds = headerView.bounds
+        bounds.size.height = height
+        headerView.bounds = bounds
+        return headerView
+    }
+    
     /// Add Subviews
     func addSubviews() {
-        // Add TitleViewController with Constraints
-        self.add(self.titleViewController, constraints: [
-            self.titleViewController.view.topAnchor.constraint(
-                equalTo: self.anchor.topAnchor,
-                constant: self.configuration.titleView.insets.top
-            ),
-            self.titleViewController.view.leadingAnchor.constraint(
-                equalTo: self.anchor.leadingAnchor,
-                constant: self.configuration.titleView.insets.left
-            ),
-            self.titleViewController.view.trailingAnchor.constraint(
-                equalTo: self.anchor.trailingAnchor,
-                constant: -self.configuration.titleView.insets.right
-            )
-        ])
+        var itemsTopAnchor = self.anchor.topAnchor
+        var itemsTopAnchorConstant = self.configuration.itemsView.insets.top
+        if self.configuration.titleMode == .fixed {
+            // Add TitleViewController with Constraints
+            self.add(self.titleViewController, constraints: [
+                self.titleViewController.view.topAnchor.constraint(
+                    equalTo: self.anchor.topAnchor,
+                    constant: self.configuration.titleView.insets.top
+                ),
+                self.titleViewController.view.leadingAnchor.constraint(
+                    equalTo: self.anchor.leadingAnchor,
+                    constant: self.configuration.titleView.insets.left
+                ),
+                self.titleViewController.view.trailingAnchor.constraint(
+                    equalTo: self.anchor.trailingAnchor,
+                    constant: -self.configuration.titleView.insets.right
+                )
+            ])
+            itemsTopAnchor = self.titleViewController.view.bottomAnchor
+            itemsTopAnchorConstant = self.configuration.itemsView.insets.top + self.configuration.titleView.insets.bottom
+        } else if let itemsViewController = self.itemsViewController as? WhatsNewItemsViewController {
+            itemsViewController.tableView.tableHeaderView = getHeaderView()
+        }
         // Add ButtonViewController with Constraints
         self.add(self.buttonViewController, constraints: [
             self.buttonViewController.view.leadingAnchor.constraint(
@@ -272,8 +291,8 @@ extension WhatsNewViewController {
         // Add ItemsViewController with Constraints
         self.add(self.itemsViewController, constraints: [
             self.itemsViewController.view.topAnchor.constraint(
-                equalTo: self.titleViewController.view.bottomAnchor,
-                constant: self.configuration.itemsView.insets.top + self.configuration.titleView.insets.bottom
+                equalTo: itemsTopAnchor,
+                constant: itemsTopAnchorConstant
             ),
             self.itemsViewController.view.leadingAnchor.constraint(
                 equalTo: self.anchor.leadingAnchor,

--- a/WhatsNewKit.xcodeproj/project.pbxproj
+++ b/WhatsNewKit.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		2264FE192441B2630030A4CE /* TitleModeConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2264FE182441B2630030A4CE /* TitleModeConfiguration.swift */; };
 		3D04214620C2D68C00DA5126 /* BaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D04214520C2D68C00DA5126 /* BaseTests.swift */; };
 		3D04215120C2D6A100DA5126 /* WhatsNewViewControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D04214720C2D6A000DA5126 /* WhatsNewViewControllerTests.swift */; };
 		3D04215320C2D6A100DA5126 /* WhatsNewVersionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D04214B20C2D6A100DA5126 /* WhatsNewVersionTests.swift */; };
@@ -97,6 +98,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		2264FE182441B2630030A4CE /* TitleModeConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleModeConfiguration.swift; sourceTree = "<group>"; };
 		3D04214520C2D68C00DA5126 /* BaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseTests.swift; sourceTree = "<group>"; };
 		3D04214720C2D6A000DA5126 /* WhatsNewViewControllerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WhatsNewViewControllerTests.swift; sourceTree = "<group>"; };
 		3D04214B20C2D6A100DA5126 /* WhatsNewVersionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WhatsNewVersionTests.swift; sourceTree = "<group>"; };
@@ -235,6 +237,7 @@
 				3DF12C2A2210AE41006473F0 /* ContentModeConfiguration.swift */,
 				3D330EC3217B8E8E002359E7 /* HapticFeedbackConfiguration.swift */,
 				3D33221C21C416E900B2949F /* SecondaryTitleColorConfiguration.swift */,
+				2264FE182441B2630030A4CE /* TitleModeConfiguration.swift */,
 				3DF12C2C2210AF51006473F0 /* ItemsCountConfiguration.swift */,
 			);
 			path = Configurations;
@@ -617,6 +620,7 @@
 				3D29914A217B691100132C91 /* ExampleViewController+PresentWhatsNew.swift in Sources */,
 				3DC8A6AB20AED02400292C94 /* AppDelegate.swift in Sources */,
 				3D299152217B6E9600132C91 /* TintColorConfiguration.swift in Sources */,
+				2264FE192441B2630030A4CE /* TitleModeConfiguration.swift in Sources */,
 				3D375BA020BC6582005DE31B /* UIColor+Main.swift in Sources */,
 				3D299150217B6E8500132C91 /* BackgroundColorConfiguration.swift in Sources */,
 				3D299146217B5EDD00132C91 /* ConfigurationsTableViewCell.swift in Sources */,


### PR DESCRIPTION
I added the option to allow users to customise the view to show the title view in the items view controller so that it scrolls with the rest of the content. This is consistent with how Apple show's their "what's changed".

The main priority was to not break existing user's experience so the default mode is to keep the title in its sticky position as it stood prior to this pull request.

I did need to bump the swift lint file length by 10 in order to support the changes I added.

Please let me know if you require any changes as I'm just trying to help out the open-source community :)