### PR TITLE
Add checks to prevent invalid context error.

### DIFF
--- a/Sources/Components/Buttons/WhatsNewButtonViewController+CompletionButton.swift
+++ b/Sources/Components/Buttons/WhatsNewButtonViewController+CompletionButton.swift
@@ -151,6 +151,10 @@ private extension UIImage {
         _ color: UIColor,
         size: CGSize = .init(width: 1, height: 1)
     ) -> UIImage? {
+        // Early return if size is (0, 0) to prevent context creation falure
+        if size.width == 0 && size.height == 0 {
+          return nil
+        }
         // Initialize rect
         let rect = CGRect(x: 0, y: 0, width: size.width, height: size.height)
         // Begin Graphics Context


### PR DESCRIPTION
I found a weird error log regarding invalid `CGContext` when using this framework.
![Error regarding invalid context](https://user-images.githubusercontent.com/8158163/80859242-aa16f800-8c91-11ea-8f42-76e6cfe2d023.png)

After some investigation, I found its cause:

`CompletionButton` is redrawing its background image at `traitCollectionDidChange`, which is called before `layoutSubviews`. At early initialization stage, the button may have empty frame with both height and width set to 0, resulting "invalid context error" when drawing background image.

This commit adds extra check to prevent creating context when frame is empty, delaying the creation of background image to `layoutSubviews` call.