### PR TITLE
Adjust image resizing so that `fixed` preserves the aspect ratio

### DIFF
--- a/Sources/Configuration/WhatsNewViewController+ItemsView.swift
+++ b/Sources/Configuration/WhatsNewViewController+ItemsView.swift
@@ -126,7 +126,7 @@ public extension WhatsNewViewController.ItemsView {
     enum ImageSize: Equatable, Hashable {
         /// The original Image Size
         case original
-        /// A fixed height by keeping the aspect ratio
+        /// A fixed size square which contains the image, with a preserved aspect ratio
         case fixed(height: Double)
     }
     


### PR DESCRIPTION
Fixes https://github.com/SvenTiigi/WhatsNewKit/issues/41

This adjusts the image resizing code. As before, it produces a square image of the specified size. Instead of stretching the image to fit the square, it now fits the image within the target size, preserving its aspect ratio:

<img src="https://user-images.githubusercontent.com/2078225/84827569-91358c80-b01c-11ea-9f9e-462174e4f87f.png" width="300"/>