### PR TITLE
Make version comparison work correctly when minor or patch > 9

### DIFF
--- a/Sources/Models/WhatsNew+Version.swift
+++ b/Sources/Models/WhatsNew+Version.swift
@@ -58,8 +58,7 @@ extension WhatsNew.Version: Comparable {
         lhs: WhatsNew.Version,
         rhs: WhatsNew.Version
     ) -> Bool {
-        let sum: (WhatsNew.Version) -> Int = { $0.major * 100 + $0.minor * 10 + $0.patch }
-        return sum(lhs) < sum(rhs)
+        return lhs.description.compare(rhs.description, options: .numeric) == .orderedAscending
     }
     
 }

--- a/Tests/Models/WhatsNewVersionTests.swift
+++ b/Tests/Models/WhatsNewVersionTests.swift
@@ -71,4 +71,20 @@ class WhatsNewVersionTests: BaseTests {
         XCTAssert(version1 > version0)
     }
     
+    func testLargeMinorVersionComparable() {
+        let version0 = WhatsNew.Version(major: 3, minor: 17, patch: 7)
+        let version1 = WhatsNew.Version(major: 4, minor: 7, patch: 7)
+        XCTAssertTrue(version0 < version1)
+        XCTAssertTrue(version1 > version0)
+        XCTAssertFalse(version1 == version0)
+    }
+    
+    func testEquality() {
+        let version0 = WhatsNew.Version(major: 1, minor: 0, patch: 0)
+        let version1 = WhatsNew.Version(major: 1, minor: 0, patch: 0)
+        XCTAssertFalse(version0 < version1)
+        XCTAssertFalse(version1 > version0)
+        XCTAssertTrue(version1 == version0)
+    }
+    
 }


### PR DESCRIPTION
Minor and patch versions can be 10 or larger and the math that was used to compare versions would be incorrect in these cases. For example:

```
3.17.7 = 3 * 100 + 17 * 10 + 7 = 477
4.7.7  = 4 * 100 +  7 * 10 + 7 = 477
```

Instead this PR changes the code to perform a numeric comparison against the description strings.

I have added two additional tests, one which ensures the code can never regress to the above example, and a second which also just sanity checks equality.