### PR TITLE
Feature - TableView Bounces Configurations

### DIFF
--- a/Sources/Components/Items/WhatsNewItemsViewController.swift
+++ b/Sources/Components/Items/WhatsNewItemsViewController.swift
@@ -57,6 +57,12 @@ final class WhatsNewItemsViewController: UIViewController {
             // Set semantic content attribute to force right to left
             tableView.semanticContentAttribute = .forceRightToLeft
         }
+
+        /// Set tableView bounces configuration based on itemViewConfiguration
+        tableView.bounces = (configuration.itemsView.bounces.isEmpty == false)
+        tableView.alwaysBounceVertical = configuration.itemsView.bounces.contains(.vertical)
+        tableView.alwaysBounceHorizontal = configuration.itemsView.bounces.contains(.horizontal)
+
         // Return TableView
         return tableView
     }()

--- a/Sources/Configuration/WhatsNewViewController+ItemsView.swift
+++ b/Sources/Configuration/WhatsNewViewController+ItemsView.swift
@@ -44,6 +44,8 @@ public extension WhatsNewViewController {
         
         /// The Insets
         public var insets: UIEdgeInsets
+
+        public var bounces: Bounces
         
         /// Default initializer
         ///
@@ -68,7 +70,8 @@ public extension WhatsNewViewController {
             layout: Layout = .left,
             contentMode: ContentMode = .top,
             animation: Animation? = nil,
-            insets: UIEdgeInsets = .init(top: 15, left: 20, bottom: 5, right: 20)
+            insets: UIEdgeInsets = .init(top: 15, left: 20, bottom: 5, right: 20),
+            bounces: Bounces  = [.vertical]
         ) {
             self.titleFont = titleFont
             self.titleColor = titleColor
@@ -80,6 +83,7 @@ public extension WhatsNewViewController {
             self.contentMode = contentMode
             self.animation = animation
             self.insets = insets
+            self.bounces = bounces
         }
         
     }
@@ -140,3 +144,32 @@ public extension WhatsNewViewController.ItemsView.ImageSize {
     static let preferred: WhatsNewViewController.ItemsView.ImageSize = .fixed(height: 50)
     
 }
+
+// MARK: - ItemsView.Bounces
+
+public extension WhatsNewViewController.ItemsView {
+
+  /// Bounces, options sets to allow vertical or horizontal bounces
+  struct Bounces: OptionSet {
+
+    // MARK: - Properties
+
+    public let rawValue: Int
+
+    // MARK: - Definitions
+
+    public static let vertical = Bounces(rawValue: 1 << 0)
+    public static let horizontal = Bounces(rawValue: 1 << 1)
+
+    public static let all: Bounces = [.vertical, .horizontal]
+
+    // MARK: - Initializer
+
+    public init(rawValue: Int) {
+      self.rawValue = rawValue
+    }
+
+  }
+
+}
+


### PR DESCRIPTION
Working w/ this and I found that I wish the `Items` tableView had it's `bounces` disabled.
It seemed this behaviour was defaults until the following commit:
>https://github.com/SvenTiigi/WhatsNewKit/commit/2b4bbac4c176aa7cd607a6646165b0c02a5ec3fd

Which simply re-enabled them, Without taking in consideration any user configuration.
I've simply added a configuration attribute into `ItemsView` definition.

`ItemsView.Bounces` is an OptionSet allowing to request `vertical` / `horizontal` or both configuration.


I've setup the `defaults` to `[.vertical]` which mimic the behaviour set currently.