### PR TITLE
Group features in VoiceOver

### DIFF
--- a/Sources/View/WhatsNewView.swift
+++ b/Sources/View/WhatsNewView.swift
@@ -169,7 +169,7 @@ private extension WhatsNewView {
                 .fixedSize(horizontal: false, vertical: true)
             }
             .multilineTextAlignment(.leading)
-        }
+        }.accessibilityElement(children: .combine)
     }
     
 }


### PR DESCRIPTION
Currently when using VoiceOver, each item within a feature (the image, title and description) are read separately. They should be treated as one unit.