### PR TITLE
Fix title color by using the parameter foregroundColor in WhatsNew.Title

### DIFF
--- a/Sources/View/WhatsNewView.swift
+++ b/Sources/View/WhatsNewView.swift
@@ -128,6 +128,7 @@ private extension WhatsNewView {
             whatsNewText: self.whatsNew.title.text
         )
         .font(.largeTitle.bold())
+        .foregroundColor(self.whatsNew.title.foregroundColor)
         .multilineTextAlignment(.center)
         .fixedSize(horizontal: false, vertical: true)
     }


### PR DESCRIPTION
The custom color wasn't taken into account previously. The only option to color the title was to use an AttributedString.
Creating the Text of the Title through an AttributedString still works and its colors attributes overrides the foregroundColor.
But if the title is created with a simple string the foregroundColor will then be applied. 